### PR TITLE
Add Root makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+MODULES=debug audio clockgen codec ctrl exceptionman ge init interruptman \
+iofilemgr led libatrac3plus loadcore loadexec mediaman memlmd me_wrapper \
+syscon sysmem systimer usersystemlib wlanfirm
+
+all: $(MODULES)
+
+utils:
+	@$(MAKE) -C $@
+
+$(MODULES): utils
+	@$(MAKE) -C "src/$@"
+
+clean:
+	@$(foreach module, $(MODULES), $(MAKE) -C "src/$(module)" $@;)
+	@$(MAKE) -C utils $@
+
+mrproper: clean
+	@$(MAKE) -C utils $@
+
+.PHONY: utils clean mrproper
+

--- a/lib/common.mak
+++ b/lib/common.mak
@@ -7,4 +7,5 @@ AS       = psp-gcc
 FIXUP    = psp-fixup-imports
 AR       = psp-ar
 RANLIB   = psp-ranlib
+PSPSDK   = $(shell psp-config --pspsdk-path)
 

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,0 +1,12 @@
+TARGETS=kprxgen fixup-imports build-exports basic-decompiler
+
+all: $(TARGETS)
+
+$(TARGETS):
+	@$(MAKE) -C $@
+
+clean mrproper:
+	@$(foreach target, $(TARGETS), $(MAKE) -C $(target) $@;)
+
+.PHONY: $(TARGETS) clean mrproper
+


### PR DESCRIPTION
Currently to build all modules:
- make all the `utils/*/*`
- make all the `src/*/*`

Let's make this simpler by adding a makefile in the root of the project.
