### PR TITLE
Fix compile errors with latest psp toolchain

### DIFF
--- a/utils/build-exports/psp-build-exports.c
+++ b/utils/build-exports/psp-build-exports.c
@@ -325,10 +325,8 @@ void build_exports_output_extern(struct psp_export *pHead)
 	pExp = pHead;
 	while(pExp != NULL)
 	{
-	    if (strchr(pExp->name, '+') == NULL)
-	    {
-    		fprintf(stdout, "extern char %s;\n", pExp->name);
-	    }
+		if (strchr(pExp->name, '+') == NULL)
+			fprintf(stdout, "extern char %s;\n", pExp->name);
 		pExp = pExp->pNext;
 	}
 }

--- a/utils/build-exports/psp-build-exports.c
+++ b/utils/build-exports/psp-build-exports.c
@@ -326,7 +326,9 @@ void build_exports_output_extern(struct psp_export *pHead)
 	while(pExp != NULL)
 	{
 	    if (strchr(pExp->name, '+') == NULL)
+	    {
     		fprintf(stdout, "extern char %s;\n", pExp->name);
+	    }
 		pExp = pExp->pNext;
 	}
 }

--- a/utils/fixup-imports/psp-fixup-imports.c
+++ b/utils/fixup-imports/psp-fixup-imports.c
@@ -613,16 +613,16 @@ int fixup_functions(void)
 	int count;
 
     if(g_stubtext == NULL || g_nid == NULL) // no imported functions
-    {
-        return 1;
-    }
+		return 1;
 
 	count = g_stubtext->iSize / 8;
 	pText = (unsigned int *) g_stubtext->pData;
 	pNid = (unsigned int *) g_nid->pData;
 
 	if(g_verbose)
+	{
 		fprintf(stderr, "Import count %d\n", count);
+	}
 
 	while(count > 0)
 	{

--- a/utils/fixup-imports/psp-fixup-imports.c
+++ b/utils/fixup-imports/psp-fixup-imports.c
@@ -611,8 +611,8 @@ int fixup_functions(void)
 	unsigned int *pNid;
 	struct PspModuleImport *pLastImport = NULL;
 	int count;
-
-    if(g_stubtext == NULL || g_nid == NULL) // no imported functions
+	
+	if(g_stubtext == NULL || g_nid == NULL) // no imported functions
 		return 1;
 
 	count = g_stubtext->iSize / 8;

--- a/utils/fixup-imports/psp-fixup-imports.c
+++ b/utils/fixup-imports/psp-fixup-imports.c
@@ -622,9 +622,7 @@ int fixup_functions(void)
 	pNid = (unsigned int *) g_nid->pData;
 
 	if(g_verbose)
-	{
 		fprintf(stderr, "Import count %d\n", count);
-	}
 
 	while(count > 0)
 	{

--- a/utils/fixup-imports/psp-fixup-imports.c
+++ b/utils/fixup-imports/psp-fixup-imports.c
@@ -613,7 +613,9 @@ int fixup_functions(void)
 	int count;
 
     if(g_stubtext == NULL || g_nid == NULL) // no imported functions
+    {
         return 1;
+    }
 
 	count = g_stubtext->iSize / 8;
 	pText = (unsigned int *) g_stubtext->pData;


### PR DESCRIPTION
Due to the -Werror flag, the error "If statements does not guard" prevent these (build-exports and fixup-imports) from being compiled.