### PR TITLE
Fix various warnings caught by GCC 9 in newer psp-toolchain

### DIFF
--- a/include/common/module.h
+++ b/include/common/module.h
@@ -138,8 +138,8 @@ enum SceModulePrivilegeLevel {
 /**
  * Module entry functions.
  */
-#define SCE_MODULE_BOOTSTART(name)      int module_start(int arglen, void *argp) __attribute__((alias(name))); \
-                                        int module_bootstart(int arglen, void *argp) __attribute__((alias(name)))
+#define SCE_MODULE_BOOTSTART(name)      int module_start(SceSize argSize, const void *argBlock) __attribute__((alias(name))); \
+                                        int module_bootstart(SceSize argSize, const void *argBlock) __attribute__((alias(name)))
 
 #define SCE_MODULE_REBOOT_BEFORE(name)  int module_reboot_before(void) __attribute__((alias(name)))
 #define SCE_MODULE_REBOOT_PHASE(name)   int module_reboot_phase(void) __attribute__((alias(name)))

--- a/include/common/module.h
+++ b/include/common/module.h
@@ -141,8 +141,9 @@ enum SceModulePrivilegeLevel {
 #define SCE_MODULE_BOOTSTART(name)      int module_start(SceSize argSize, const void *argBlock) __attribute__((alias(name))); \
                                         int module_bootstart(SceSize argSize, const void *argBlock) __attribute__((alias(name)))
 
-#define SCE_MODULE_REBOOT_BEFORE(name)  int module_reboot_before(void) __attribute__((alias(name)))
-#define SCE_MODULE_REBOOT_PHASE(name)   int module_reboot_phase(void) __attribute__((alias(name)))
+#define SCE_MODULE_REBOOT_BEFORE(name)  int module_reboot_before(void *arg0, s32 arg1, s32 arg2, s32 arg3) __attribute__((alias(name)))
+#define SCE_MODULE_REBOOT_BEFORE_FOR_USER(name)  int module_reboot_before(SceSize arglen, void *argp) __attribute__((alias(name)))
+#define SCE_MODULE_REBOOT_PHASE(name)   int module_reboot_phase(s32 arg1, void *arg2, s32 arg3, s32 arg4) __attribute__((alias(name)))
 #define SCE_MODULE_STOP(name)           int module_stop(void) __attribute__((alias(name)))
 
 #define SCE_MODULE_INFO(name, attributes, majorVersion, minorVersion) \

--- a/include/loadcore.h
+++ b/include/loadcore.h
@@ -168,6 +168,10 @@ enum SceLibAttr {
 /** Boot Callback function. */
 typedef s32 (*SceKernelBootCallbackFunction)(void *data, s32 arg, void *opt);
 
+/** Reboot preparation functions */
+typedef s32 (*SceKernelRebootBeforeForKernel)(void *arg1, s32 arg2, s32 arg3, s32 arg4);
+typedef s32 (*SceKernelRebootPhaseForKernel)(s32 arg1, void *arg2, s32 arg3, s32 arg4);
+
 /** 
  * This structure represents a function stub belonging to same privilege-level linked libraries, 
  * i.e. a kernel resident library linked with a kernel stub library. 
@@ -746,12 +750,12 @@ typedef struct SceModule {
      * A pointer to a module's rebootBefore entry function. This function is probably executed 
      * before a reboot. 
      */
-    SceKernelRebootKernelThreadEntry moduleRebootBefore; //92
+    SceKernelRebootBeforeForKernel moduleRebootBefore; //92
     /** 
      * A pointer to a module's rebootPhase entry function. This function is probably executed 
      * during a reboot. 
      */
-    SceKernelRebootKernelThreadEntry moduleRebootPhase; //96
+    SceKernelRebootPhaseForKernel moduleRebootPhase; //96
     /** 
      * The entry address of the module. It is the offset from the start of the TEXT segment to the 
      * program's entry point. 

--- a/include/pspmoduleexport.h
+++ b/include/pspmoduleexport.h
@@ -13,7 +13,7 @@ struct SceLibraryEntry {
     unsigned char   entLen;
     unsigned char   varCount;
     unsigned short  funcCount;
-    void *          entrytable;
+    const void *    entrytable;
 };
 
 #endif

--- a/include/sysmem_sysclib.h
+++ b/include/sysmem_sysclib.h
@@ -47,7 +47,7 @@ int strtol(const char *nptr, char **endptr, int base);
 u32 strtoul(char *nptr, char **endptr, int base);
 int strncmp(const char *s1, const char *s2, int n);
 char *strncpy(char *dest, const char *src, int n);
-u32 strnlen(const char *s, int maxlen);
+u32 strnlen(const char *s, u32 maxlen);
 u32 strlen(const char *s);
 char *strrchr(char *s, int c);
 char *strpbrk(char *s, const char *accept);

--- a/lib/build.mak
+++ b/lib/build.mak
@@ -4,7 +4,7 @@
 include ../../lib/common.mak
 
 INCLUDE = -I../../include
-WARNINGS = -Wall -Wextra -Werror
+WARNINGS = -Wall -Wextra -Werror -Wno-pragmas
 
 # Only keep builtins for memcpy, memset for their inline function
 BUILTINS_DISABLE = -fno-builtin-bcmp \

--- a/src/clockgen/clockgen.c
+++ b/src/clockgen/clockgen.c
@@ -253,7 +253,7 @@ int _sceClockgenModuleStart(SceSize argSize __attribute__((unused)), const void 
 }
 
 //0x00000320
-s32 _sceClockgenModuleRebootBefore()
+s32 _sceClockgenModuleRebootBefore(void *arg0 __attribute__((unused)), s32 arg1 __attribute__((unused)), s32 arg2 __attribute__((unused)), s32 arg3 __attribute__((unused)))
 {
     s32 oldRegSS;
     s32 curRegSS;

--- a/src/clockgen/clockgen.c
+++ b/src/clockgen/clockgen.c
@@ -242,7 +242,7 @@ s32 sceClockgenSetSpectrumSpreading(s32 mode)
 }
 
 //0x000002B4
-int _sceClockgenModuleStart(int args __attribute__((unused)), void *argp __attribute__((unused)))
+int _sceClockgenModuleStart(SceSize argSize __attribute__((unused)), const void *argBlock __attribute__((unused)))
 {
     sceClockgenInit();
 

--- a/src/clockgen/clockgen.c
+++ b/src/clockgen/clockgen.c
@@ -242,7 +242,7 @@ s32 sceClockgenSetSpectrumSpreading(s32 mode)
 }
 
 //0x000002B4
-s32 _sceClockgenModuleStart(SceSize args __attribute__((unused)), void *argp __attribute__((unused)))
+int _sceClockgenModuleStart(int args __attribute__((unused)), void *argp __attribute__((unused)))
 {
     sceClockgenInit();
 
@@ -253,7 +253,7 @@ s32 _sceClockgenModuleStart(SceSize args __attribute__((unused)), void *argp __a
 }
 
 //0x00000320
-s32 _sceClockgenModuleRebootBefore(SceSize args __attribute__((unused)), void *argp __attribute__((unused)))
+s32 _sceClockgenModuleRebootBefore()
 {
     s32 oldRegSS;
     s32 curRegSS;

--- a/src/clockgen/clockgen_int.h
+++ b/src/clockgen/clockgen_int.h
@@ -12,7 +12,7 @@
  *
  * @return SCE_ERROR_OK.
  */
-static s32 _sceClockgenModuleStart(SceSize args, void *argp);
+static int _sceClockgenModuleStart(int args, void *argp);
 
 /**
  * Deinits the module.
@@ -21,7 +21,7 @@ static s32 _sceClockgenModuleStart(SceSize args, void *argp);
  *
  * @return SCE_ERROR_OK.
  */
-static s32 _sceClockgenModuleRebootBefore(SceSize args, void *argp);
+static int _sceClockgenModuleRebootBefore();
 
 /**
  * Event handler function.

--- a/src/clockgen/clockgen_int.h
+++ b/src/clockgen/clockgen_int.h
@@ -12,7 +12,7 @@
  *
  * @return SCE_ERROR_OK.
  */
-static int _sceClockgenModuleStart(int args, void *argp);
+static int _sceClockgenModuleStart(SceSize argSize, const void *argBlock);
 
 /**
  * Deinits the module.

--- a/src/codec/codec.c
+++ b/src/codec/codec.c
@@ -506,7 +506,7 @@ int sceCodec_driver_FC355DE0()
     return 0;
 }
 
-int sceCodecStopEntry()
+int sceCodecStopEntry(void *arg0 __attribute__((unused)), s32 arg1 __attribute__((unused)), s32 arg2 __attribute__((unused)), s32 arg3 __attribute__((unused)))
 {
     sub_01FC(-1, -1, -1, -1);
     sceKernelUnregisterSysEventHandler(&g_sysEv);

--- a/src/ctrl/ctrl.c
+++ b/src/ctrl/ctrl.c
@@ -2135,7 +2135,7 @@ s32 _sceCtrlModuleStart(SceSize argSize __attribute__((unused)), const void *arg
     return SCE_KERNEL_RESIDENT;
 }
 
-s32 _sceCtrlModuleRebootBefore()
+s32 _sceCtrlModuleRebootBefore(void *arg0 __attribute__((unused)), s32 arg1 __attribute__((unused)), s32 arg2 __attribute__((unused)), s32 arg3 __attribute__((unused)))
 {
     sceCtrlEnd();   
     return SCE_KERNEL_STOP_SUCCESS;

--- a/src/ctrl/ctrl.c
+++ b/src/ctrl/ctrl.c
@@ -2129,11 +2129,8 @@ static s32 _sceCtrlReadBuf(SceCtrlData2 *pData, u8 nBufs, u32 inputMode, u8 mode
     return numReadIntBufs;
 }
 
-s32 _sceCtrlModuleStart(s32 argc, void *argp) 
+s32 _sceCtrlModuleStart(SceSize argSize __attribute__((unused)), const void *argBlock __attribute__((unused)))
 {
-	(void)argc;
-	(void)argp;
-
     sceCtrlInit();    
     return SCE_KERNEL_RESIDENT;
 }

--- a/src/ctrl/ctrl.c
+++ b/src/ctrl/ctrl.c
@@ -618,8 +618,11 @@ s32 sceCtrlInit(void)
    
     deci2Ops = sceKernelDeci2pReferOperations();
     if (deci2Ops != NULL && deci2Ops->size == 48) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
         func = (void (*)(SceKernelDeci2Ops *))deci2Ops->ops[10];
         func(&g_ctrlDeci2Ops);
+#pragma GCC diagnostic pop
     }
     return SCE_ERROR_OK;
 }
@@ -1968,7 +1971,7 @@ static s32 _sceCtrlReadBuf(SceCtrlData2 *pData, u8 nBufs, u32 inputMode, u8 mode
     s32 status;
     s32 intrState;
 
-    if (nBufs >= CTRL_NUM_INTERNAL_CONTROLLER_BUFFERS)
+	if (nBufs >= CTRL_NUM_INTERNAL_CONTROLLER_BUFFERS)
         return SCE_ERROR_INVALID_SIZE;
 
 	if (inputMode > CTRL_NUM_EXTERNAL_INPUT_MODES)
@@ -1986,7 +1989,7 @@ static s32 _sceCtrlReadBuf(SceCtrlData2 *pData, u8 nBufs, u32 inputMode, u8 mode
     }
     if (pspK1IsUserMode())
         intDataPtr = &g_ctrl.userModeData;
-    else
+	else
         intDataPtr = &g_ctrl.kernelModeData;
 
 	if (inputMode != SCE_CTRL_EXTERNAL_INPUT_NONE && intDataPtr->pCtrlInputBuffers[inputMode] == NULL)
@@ -2135,11 +2138,8 @@ s32 _sceCtrlModuleStart(s32 argc, void *argp)
     return SCE_KERNEL_RESIDENT;
 }
 
-s32 _sceCtrlModuleRebootBefore(s32 argc, void *argp) 
+s32 _sceCtrlModuleRebootBefore()
 {
-	(void)argc;
-	(void)argp;
-
     sceCtrlEnd();   
     return SCE_KERNEL_STOP_SUCCESS;
 }

--- a/src/exceptionman/exceptions.c
+++ b/src/exceptionman/exceptions.c
@@ -37,8 +37,11 @@ char g_stackCtx[192] = {0};
 // 1640
 SceExceptions ExcepManCB = { { NULL }, { NULL }, NULL, NULL, { { NULL, NULL } }};
 
-int ExcepManInit(void)
+int ExcepManInit(s32 argc, void *argp)
 {
+	(void)argc;
+	(void)argp;
+
     dbg_init(1, FB_HARDWARE, FAT_HARDWARE);
     dbg_printf("-- ExcepManInit()\n");
     int oldIntr = suspendIntr();

--- a/src/exceptionman/exceptions.c
+++ b/src/exceptionman/exceptions.c
@@ -37,11 +37,8 @@ char g_stackCtx[192] = {0};
 // 1640
 SceExceptions ExcepManCB = { { NULL }, { NULL }, NULL, NULL, { { NULL, NULL } }};
 
-int ExcepManInit(s32 argc, void *argp)
+int ExcepManInit(SceSize argSize __attribute__((unused)), const void *argBlock __attribute__((unused)))
 {
-	(void)argc;
-	(void)argp;
-
     dbg_init(1, FB_HARDWARE, FAT_HARDWARE);
     dbg_printf("-- ExcepManInit()\n");
     int oldIntr = suspendIntr();

--- a/src/ge/ge.c
+++ b/src/ge/ge.c
@@ -91,8 +91,8 @@ int _sceGeSetInternalReg(int type, int arg1, int arg2, int arg3);
 int _sceGeInterrupt(int arg0, int arg1, int arg2);
 s32 _sceGeSysEventHandler(s32 ev_id, char *ev_name, void *param, s32 *result);
 int _sceGeModuleStart();
-int _sceGeModuleRebootPhase(int unk);
-int _sceGeModuleRebootBefore();
+int _sceGeModuleRebootPhase(s32 arg0 __attribute__((unused)), void *arg1 __attribute__((unused)), s32 arg2 __attribute__((unused)), s32 arg3 __attribute__((unused)));
+int _sceGeModuleRebootBefore(void *arg0 __attribute__((unused)), s32 arg1 __attribute__((unused)), s32 arg2 __attribute__((unused)), s32 arg3 __attribute__((unused)));
 int _sceGeSetBaseRadr(int arg0, int arg1, int arg2);
 int _sceGeEdramResume();
 int _sceGeEdramSuspend();
@@ -1249,14 +1249,14 @@ int _sceGeModuleStart()
     return 0;
 }
 
-int _sceGeModuleRebootPhase(int unk)
+int _sceGeModuleRebootPhase(s32 arg0 __attribute__((unused)), void *arg1 __attribute__((unused)), s32 arg2 __attribute__((unused)), s32 arg3 __attribute__((unused)))
 {
-    if (unk == 1)
+    if (arg0 == 1)
         sceGeBreak(0, NULL);    // 24E4
     return 0;
 }
 
-int _sceGeModuleRebootBefore()
+int _sceGeModuleRebootBefore(void *arg0 __attribute__((unused)), s32 arg1 __attribute__((unused)), s32 arg2 __attribute__((unused)), s32 arg3 __attribute__((unused)))
 {
     sceGeEnd();
     return 0;

--- a/src/ge/ge.c
+++ b/src/ge/ge.c
@@ -20,7 +20,10 @@ SCE_MODULE_INFO("sceGE_Manager", SCE_MODULE_KERNEL | SCE_MODULE_ATTR_CANT_STOP |
                                  | SCE_MODULE_ATTR_EXCLUSIVE_START, 1, 11);
 SCE_MODULE_BOOTSTART("_sceGeModuleStart");
 SCE_MODULE_REBOOT_BEFORE("_sceGeModuleRebootBefore");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattribute-alias"
 SCE_MODULE_REBOOT_PHASE("_sceGeModuleRebootPhase");
+#pragma GCC diagnostic pop
 SCE_SDK_VERSION(SDK_VERSION);
 
 #define HW_GE_RESET     HW(0xBD400000)

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -77,7 +77,7 @@ SceNpDrm g_npDrmData;
 SceLoadCoreBootModuleInfo g_mod;
 
 /* Initialize Init's control block. */
-static void InitCBInit(SceLoadCoreBootInfo *bootInfo)
+static void InitCBInit(const SceLoadCoreBootInfo *bootInfo)
 {   
     if (bootInfo->configFile == NULL)
         g_hasConfigFile = SCE_FALSE;
@@ -326,7 +326,7 @@ static s32 CleanupPhase2(SceLoadCoreBootInfo *bootInfo)
 }
 
 /* Allocate memory for protected modules. */
-static void ProtectHandling(SceLoadCoreBootInfo *bootInfo)
+static void ProtectHandling(const SceLoadCoreBootInfo *bootInfo)
 {
     SceUID partId;
     SceSysmemMemoryBlockInfo blkInfo;
@@ -912,11 +912,11 @@ asm(".word init_patch\n");
 #endif
 
 /* Setup the boot process of the rest of the PSP kernel modules. */
-s32 InitInit(s32 argc __attribute__((unused)), void *argp)
+s32 InitInit(SceSize argSize __attribute__((unused)), const void *argBlock __attribute__((unused)))
 {
     SceUID threadId;
      
-    SceLoadCoreBootInfo *bootInfo = argp;
+    const SceLoadCoreBootInfo *bootInfo = argBlock;
     g_MemBase = bootInfo->memBase;
     g_MemSize = bootInfo->memSize;
     

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -912,7 +912,7 @@ asm(".word init_patch\n");
 #endif
 
 /* Setup the boot process of the rest of the PSP kernel modules. */
-s32 InitInit(SceSize argc __attribute__((unused)), void *argp)
+s32 InitInit(s32 argc __attribute__((unused)), void *argp)
 {
     SceUID threadId;
      
@@ -948,9 +948,11 @@ s32 InitInit(SceSize argc __attribute__((unused)), void *argp)
         sceKernelMemset32(maxEnd, 0, SCE_USERSPACE_ADDR_K0 - (u32)maxEnd);
     } else
         sceKernelMemset32((void *)REBOOT_BASE_ADDR_K0, 0, SCE_USERSPACE_ADDR_K0 - REBOOT_BASE_ADDR_K0);
-    
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
     SceUID id = sceKernelCreateThread("SceKernelInitThread", (SceKernelThreadEntry)InitThreadEntry, 
             SCE_KERNEL_MODULE_INIT_PRIORITY, 0x4000, 0, NULL);
+#pragma GCC diagnostic pop
     
     u32 threadArgs[2] = { 
         threadId, 

--- a/src/interruptman/interruptman.c
+++ b/src/interruptman/interruptman.c
@@ -1023,7 +1023,7 @@ s32 sceKernelSetPrimarySyscallHandler(s32 syscallId, void (*syscall)())
     return 0;
 }
 
-s32 IntrManTerminate()
+s32 IntrManTerminate(void *arg0 __attribute__((unused)), s32 arg1 __attribute__((unused)), s32 arg2 __attribute__((unused)), s32 arg3 __attribute__((unused)))
 {
     dbg_printf("Called %s\n", __FUNCTION__);
     pspCop0StateSet(COP0_STATE_STATUS, pspCop0StateGet(COP0_STATE_STATUS) & 0xFFFF7BFF);

--- a/src/iofilemgr/iofilemgr.c
+++ b/src/iofilemgr/iofilemgr.c
@@ -2096,7 +2096,7 @@ int IoFileMgrInit()
     return 0;
 }
 
-int IoFileMgrRebootBefore(void)
+int IoFileMgrRebootBefore(void *arg0 __attribute__((unused)), s32 arg1 __attribute__((unused)), s32 arg2 __attribute__((unused)), s32 arg3 __attribute__((unused)))
 {
     dbg_printf("Calling %s\n", __FUNCTION__);
     SceIoDeviceList *cur = g_devList;

--- a/src/iofilemgr/stdio.c
+++ b/src/iofilemgr/stdio.c
@@ -378,7 +378,9 @@ char *fdgets(char *s, int fd)
                 *curS = '\0';
                 return NULL;
             }
+            /* FALLTHRU */
         case '\n':
+            /* FALLTHRU */
         case '\r':
             // 0748
             if (sceKernelDebugEcho() != 0)
@@ -387,6 +389,7 @@ char *fdgets(char *s, int fd)
             return s;
         case '\t':
             c = ' ';
+            /* FALLTHRU */
         default:
             // 06DC
             if ((look_ctype_table(c) & 0x97) != 0 && curS < end)

--- a/src/led/led.c
+++ b/src/led/led.c
@@ -461,13 +461,13 @@ s32 sceLedSetMode(s32 led, s32 mode, SceLedConfiguration *config)
     return SCE_ERROR_OK;
 }
 
-u32 _sceLedModuleStart(s32 argc __attribute__((unused)), void *argp __attribute__((unused)))
+s32 _sceLedModuleStart(s32 argc __attribute__((unused)), void *argp __attribute__((unused)))
 {
     sceLedInit();
     return SCE_ERROR_OK;
 }
 
-u32 _sceLedModuleRebootBefore(s32 argc __attribute__((unused)), void *argp __attribute__((unused)))
+s32 _sceLedModuleRebootBefore()
 {
     sceLedEnd();
     return SCE_ERROR_OK;

--- a/src/led/led.c
+++ b/src/led/led.c
@@ -467,7 +467,7 @@ s32 _sceLedModuleStart(SceSize argSize __attribute__((unused)), const void *argB
     return SCE_ERROR_OK;
 }
 
-s32 _sceLedModuleRebootBefore()
+s32 _sceLedModuleRebootBefore(void *arg0 __attribute__((unused)), s32 arg1 __attribute__((unused)), s32 arg2 __attribute__((unused)), s32 arg3 __attribute__((unused)))
 {
     sceLedEnd();
     return SCE_ERROR_OK;

--- a/src/led/led.c
+++ b/src/led/led.c
@@ -461,7 +461,7 @@ s32 sceLedSetMode(s32 led, s32 mode, SceLedConfiguration *config)
     return SCE_ERROR_OK;
 }
 
-s32 _sceLedModuleStart(s32 argc __attribute__((unused)), void *argp __attribute__((unused)))
+s32 _sceLedModuleStart(SceSize argSize __attribute__((unused)), const void *argBlock __attribute__((unused)))
 {
     sceLedInit();
     return SCE_ERROR_OK;

--- a/src/libatrac3plus/libatrac3plus.c
+++ b/src/libatrac3plus/libatrac3plus.c
@@ -590,7 +590,7 @@ int resetId(SceAtracId *info)
     return 0;
 }
 
-int sceAtracStartEntry(s32 argc __attribute__((unused)), void *argp __attribute__((unused)))
+int sceAtracStartEntry(SceSize argSize __attribute__((unused)), const void *argBlock __attribute__((unused)))
 {
     return (sceAtracReinit(2, 2) < 0);
 }

--- a/src/libatrac3plus/libatrac3plus.c
+++ b/src/libatrac3plus/libatrac3plus.c
@@ -590,7 +590,7 @@ int resetId(SceAtracId *info)
     return 0;
 }
 
-int sceAtracStartEntry(void)
+int sceAtracStartEntry(s32 argc __attribute__((unused)), void *argp __attribute__((unused)))
 {
     return (sceAtracReinit(2, 2) < 0);
 }

--- a/src/loadcore/hash.c
+++ b/src/loadcore/hash.c
@@ -16,7 +16,7 @@
  * 
  * Returns the index in the hash table where the array can be found
  */
-u32 getCyclicPolynomialHash(const char *str, u32 radix, u32 hashTableSize)
+__inline__ u32 getCyclicPolynomialHash(const char *str, u32 radix, u32 hashTableSize)
 {
     u32 len;
     u32 hash;

--- a/src/loadcore/hash.c
+++ b/src/loadcore/hash.c
@@ -16,7 +16,7 @@
  * 
  * Returns the index in the hash table where the array can be found
  */
-__inline__ u32 getCyclicPolynomialHash(const char *str, u32 radix, u32 hashTableSize)
+u32 getCyclicPolynomialHash(const char *str, u32 radix, u32 hashTableSize)
 {
     u32 len;
     u32 hash;

--- a/src/loadcore/hash.h
+++ b/src/loadcore/hash.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-__inline__ u32 getCyclicPolynomialHash(const char *str, u32 radix, u32 hashTableSize);
+u32 getCyclicPolynomialHash(const char *str, u32 radix, u32 hashTableSize);
 
 
 #ifdef	__cplusplus

--- a/src/loadcore/loadcore.c
+++ b/src/loadcore/loadcore.c
@@ -2013,7 +2013,7 @@ static s32 ProcessModuleExportEnt(SceModule *mod, SceResidentLibraryEntryTable *
     for (i = 0; i < lib->stubCount; i++) {        
          switch (lib->entryTable[i]) { 
          case NID_MODULE_REBOOT_PHASE: //0x00003450
-             mod->moduleRebootPhase = (SceKernelRebootKernelThreadEntry)lib->entryTable[lib->vStubCount + lib->stubCount + i]; //0x00003678
+             mod->moduleRebootPhase = (SceKernelRebootPhaseForKernel)lib->entryTable[lib->vStubCount + lib->stubCount + i]; //0x00003678
              break;
          case NID_MODULE_BOOTSTART: //0x000035DC
              mod->moduleBootstart = (SceKernelThreadEntry)lib->entryTable[lib->vStubCount + lib->stubCount + i]; //0x00003658
@@ -2025,7 +2025,7 @@ static s32 ProcessModuleExportEnt(SceModule *mod, SceResidentLibraryEntryTable *
              mod->moduleStop = (SceKernelThreadEntry)lib->entryTable[lib->vStubCount + lib->stubCount + i]; //0x00003610
              break;
          case NID_MODULE_REBOOT_BEFORE: //0x00003478
-             mod->moduleRebootBefore = (SceKernelRebootKernelThreadEntry)lib->entryTable[lib->vStubCount + lib->stubCount + i]; //0x000035D4
+             mod->moduleRebootBefore = (SceKernelRebootBeforeForKernel)lib->entryTable[lib->vStubCount + lib->stubCount + i]; //0x000035D4
              break;
          }         
     }

--- a/src/loadcore/loadcore.c
+++ b/src/loadcore/loadcore.c
@@ -673,7 +673,7 @@ static s32 aVariableLinkApply(u32 *arg1, u32 exportedVar, u32 linkOption, u32 is
  * 
  * Returns 0 on success.   
  */
-s32 loadCoreInit(s32 argc __attribute__((unused)), void *argp)
+s32 loadCoreInit(SceSize argSize __attribute__((unused)), const void *argBlock)
 {
     u32 i;
     for (i = 0; i < 480 * 272 * 2; i++) *(int*)(0x44000000 + i * 4) = 0x00FF0000;
@@ -684,8 +684,8 @@ s32 loadCoreInit(s32 argc __attribute__((unused)), void *argp)
     SceLoadCoreBootInfo *bootInfo = NULL;
     SysMemThreadConfig *sysMemThreadConfig = NULL;         
     
-    bootInfo = ((SceLoadCoreBootInfo **)argp)[0];
-    sysMemThreadConfig = ((SysMemThreadConfig **)argp)[1]; //0x00000B38
+    bootInfo = ((SceLoadCoreBootInfo **)argBlock)[0];
+    sysMemThreadConfig = ((SysMemThreadConfig **)argBlock)[1]; //0x00000B38
     g_MemSize = bootInfo->memSize; //0x00000B44
     g_MemBase = bootInfo->memBase; //0x00000B48
     

--- a/src/loadcore/loadcore.c
+++ b/src/loadcore/loadcore.c
@@ -673,7 +673,7 @@ static s32 aVariableLinkApply(u32 *arg1, u32 exportedVar, u32 linkOption, u32 is
  * 
  * Returns 0 on success.   
  */
-s32 loadCoreInit(SceSize argc __attribute__((unused)), void *argp) 
+s32 loadCoreInit(s32 argc __attribute__((unused)), void *argp)
 {
     u32 i;
     for (i = 0; i < 480 * 272 * 2; i++) *(int*)(0x44000000 + i * 4) = 0x00FF0000;
@@ -1740,27 +1740,28 @@ static s32 ReleaseLibEntCB(SceResidentLibrary *lib, SceResidentLibrary **prevLib
 
     if (lib->stubLibs != NULL) { //0x00002E08
         for (curStubLib = *stubLibPtr; curStubLib; curStubLib = *stubLibPtr) { //0x00002E24 - 0x00002EC0  
-             if (!(curStubLib->attribute & SCE_LIB_WEAK_IMPORT)) //0x00002E2C
-                 stubLibPtr = &curStubLib->next; //0x00002E30
-                 continue;
+            if (!(curStubLib->attribute & SCE_LIB_WEAK_IMPORT)) { //0x00002E2C
+                stubLibPtr = &curStubLib->next; //0x00002E30
+                continue;
+            }
             
-             nextStubLib = curStubLib->next; //0x00002E38
-             curStubLib->next = g_loadCore.unLinkedStubLibs; //0x00002E3C
-             g_loadCore.unLinkedStubLibs = curStubLib; //0x00002E44
+            nextStubLib = curStubLib->next; //0x00002E38
+            curStubLib->next = g_loadCore.unLinkedStubLibs; //0x00002E3C
+            g_loadCore.unLinkedStubLibs = curStubLib; //0x00002E44
 
-             //0x00002E58 - 0x00002E70
-             for (i = 0; i < curStubLib->stubCount; i++) {
-                  curStubLib->stubTable[i].sc.returnAddr = SYSCALL_NOT_LINKED;
-                  curStubLib->stubTable[i].sc.syscall = NOP;
-             }
-             curStubLib->status &= ~STUB_LIBRARY_LINKED; //0x00002E84
-             g_UpdateCacheRange(curStubLib->stubTable, curStubLib->stubCount * sizeof(SceStub)); //0x00002E8C
+            //0x00002E58 - 0x00002E70
+            for (i = 0; i < curStubLib->stubCount; i++) {
+                curStubLib->stubTable[i].sc.returnAddr = SYSCALL_NOT_LINKED;
+                curStubLib->stubTable[i].sc.syscall = NOP;
+            }
+            curStubLib->status &= ~STUB_LIBRARY_LINKED; //0x00002E84
+            g_UpdateCacheRange(curStubLib->stubTable, curStubLib->stubCount * sizeof(SceStub)); //0x00002E8C
              
-             aUnLinkVariableStub(lib, (SceStubLibraryEntryTable *)curStubLib->libName, curStubLib->isUserLib); //0x00002EA0
-             if (curStubLib->vStubCount != 0) //0x00002EB0
-                 g_UpdateCacheAll(); //0x00002FBC
+            aUnLinkVariableStub(lib, (SceStubLibraryEntryTable *)curStubLib->libName, curStubLib->isUserLib); //0x00002EA0
+            if (curStubLib->vStubCount != 0) //0x00002EB0
+                g_UpdateCacheAll(); //0x00002FBC
            
-             *stubLibPtr = nextStubLib; //0x00002EB8
+            *stubLibPtr = nextStubLib; //0x00002EB8
         }
         /* 
          * Verify if there are still stub libraries linked with specified

--- a/src/loadcore/module.c
+++ b/src/loadcore/module.c
@@ -514,8 +514,8 @@ static SceUID module_do_initialize(SceSysmemUidCB *cb, SceSysmemUidCB *uidWithFu
     mod->moduleStart = (SceKernelThreadEntry)SCE_KERNEL_VALUE_UNITIALIZED; //0x00007270
     mod->moduleStop = (SceKernelThreadEntry)SCE_KERNEL_VALUE_UNITIALIZED; //0x00007274
     mod->moduleBootstart = (SceKernelThreadEntry)SCE_KERNEL_VALUE_UNITIALIZED; //0x00007278
-    mod->moduleRebootBefore = (SceKernelRebootKernelThreadEntry)SCE_KERNEL_VALUE_UNITIALIZED; //0x0000727C
-    mod->moduleRebootPhase = (SceKernelRebootKernelThreadEntry)SCE_KERNEL_VALUE_UNITIALIZED; //0x00007280
+    mod->moduleRebootBefore = (SceKernelRebootBeforeForKernel)SCE_KERNEL_VALUE_UNITIALIZED; //0x0000727C
+    mod->moduleRebootPhase = (SceKernelRebootPhaseForKernel)SCE_KERNEL_VALUE_UNITIALIZED; //0x00007280
     mod->textSize = 0; //0x00007284
     mod->dataSize = 0; //0x00007288
     mod->bssSize = 0; //0x0000728C

--- a/src/loadcore/systable.c
+++ b/src/loadcore/systable.c
@@ -102,8 +102,12 @@ s32 SyscallTableInit(u32 seed, SceSyscallTable **syscallTable)
    sysCallTable->tableSize = SYSCALL_TABLE_SIZE;
    
    //0x000003B0 - 0x000003C8
-   for (i = 0; i < SYSCALL_TABLE_FUNCTION_TABLE_ENTRIES; i++) 
+   for (i = 0; i < SYSCALL_TABLE_FUNCTION_TABLE_ENTRIES; i++) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
         sysCallTable->syscalls[i] = (void (*)())UndefSyscall;
+#pragma GCC diagnostic pop
+   }
     
    //0x000003D0 - 0x000003F8
    initialSysEntTable[0].next = NULL;      

--- a/src/loadexec/loadexec.c
+++ b/src/loadexec/loadexec.c
@@ -541,6 +541,7 @@ s32 LoadExecForUser_8ADA38D3(char *file, SceKernelLoadExecParam *opt)
             vshParam.key = g_gameStr;
         else
             vshParam.key = g_umdEmuStr;
+        break;
 
     case SCE_EXEC_FILE_APITYPE_MLNAPP_MS:
     case SCE_EXEC_FILE_APITYPE_MLNAPP_EF:

--- a/src/mediaman/mediaman.c
+++ b/src/mediaman/mediaman.c
@@ -439,12 +439,9 @@ u32 sceUmdRegisterDeactivateCallBack(s32 (*deactivateCallback)(s32, void *), voi
     return SCE_ERROR_OK;
 }
 
-s32 sceUmdModuleStart(s32 argc, void *argp)
+s32 sceUmdModuleStart(SceSize argSize __attribute__((unused)), const void *argBlock __attribute__((unused)))
 {   
     s32 intrState;
-
-	(void)argc;
-	(void)argp;
     
     memset(&g_mediaMan, 0, sizeof g_mediaMan);
     

--- a/src/modulemgr/modulemgr.c
+++ b/src/modulemgr/modulemgr.c
@@ -323,11 +323,8 @@ s32 ModuleMgrRebootBefore()
 /*
  * Create the work objects (threads,...) for the module manager.
  */
-s32 ModuleMgrInit(s32 argc, void *argp)
+s32 ModuleMgrInit(SceSize argSize __attribute__((unused)), const void *argBlock __attribute__((unused)))
 {
-    (void)argc;
-    (void)argp;
-
     ChunkInit();
 
     g_ModuleManager.threadId = sceKernelCreateThread("SceKernelModmgrWorker", (SceKernelThreadEntry)exe_thread,

--- a/src/modulemgr/modulemgr.c
+++ b/src/modulemgr/modulemgr.c
@@ -309,13 +309,13 @@ static s32 exe_thread(SceSize args, void *argp)
 }
 
 // 0x0000501C
-s32 ModuleMgrRebootPhase()
+s32 ModuleMgrRebootPhase(s32 arg0 __attribute__((unused)), void *arg1 __attribute__((unused)), s32 arg2 __attribute__((unused)), s32 arg3 __attribute__((unused)))
 {
     return SCE_ERROR_OK;
 }
 
 // 0x00005024
-s32 ModuleMgrRebootBefore()
+s32 ModuleMgrRebootBefore(void *arg0 __attribute__((unused)), s32 arg1 __attribute__((unused)), s32 arg2 __attribute__((unused)), s32 arg3 __attribute__((unused)))
 {
     return sceKernelSuspendThread(g_ModuleManager.threadId); //0x00005034
 }
@@ -1427,7 +1427,7 @@ static s32 _ProcessModuleExportEnt(SceModule *pMod, SceResidentLibraryEntryTable
     for (i = 0; i < pLib->stubCount; i++) {
         switch (pLib->entryTable[i]) {
         case NID_MODULE_REBOOT_PHASE: //0x000079C0
-            pMod->moduleRebootPhase = (SceKernelRebootKernelThreadEntry)pLib->entryTable[pLib->vStubCount + pLib->stubCount + i]; //0x00007C14
+            pMod->moduleRebootPhase = (SceKernelRebootPhaseForKernel)pLib->entryTable[pLib->vStubCount + pLib->stubCount + i]; //0x00007C14
             break;
         case NID_MODULE_BOOTSTART: //0x00007B94
             pMod->moduleBootstart = (SceKernelThreadEntry)pLib->entryTable[pLib->vStubCount + pLib->stubCount + i]; //0x00007BF4
@@ -1439,7 +1439,7 @@ static s32 _ProcessModuleExportEnt(SceModule *pMod, SceResidentLibraryEntryTable
             pMod->moduleStop = (SceKernelThreadEntry)pLib->entryTable[pLib->vStubCount + pLib->stubCount + i]; //0x00007BC8
             break;
         case NID_MODULE_REBOOT_BEFORE: //0x000079E8
-            pMod->moduleRebootBefore = (SceKernelRebootKernelThreadEntry)pLib->entryTable[pLib->vStubCount + pLib->stubCount + i]; //0x00007B8C
+            pMod->moduleRebootBefore = (SceKernelRebootBeforeForKernel)pLib->entryTable[pLib->vStubCount + pLib->stubCount + i]; //0x00007B8C
             break;
         case NID_592743D8: // 0x000079D8
             break;

--- a/src/modulemgr/modulemgr.c
+++ b/src/modulemgr/modulemgr.c
@@ -197,7 +197,7 @@ static s32 exe_thread(SceSize args, void *argp)
 
         if (pModParams->modeFinish == CMD_LOAD_MODULE) //0x00000214
             break;
-
+        /* FALLTHRU */
     case CMD_RELOCATE_MODULE: // 0x0000021C
         if (pMod == NULL) {
             pMod = sceKernelCreateModule(); //0x00000448
@@ -233,7 +233,7 @@ static s32 exe_thread(SceSize args, void *argp)
         *(pModParams->pResult) = pModParams->pMod->modId; //0x00000260        
         if (pModParams->modeFinish == CMD_RELOCATE_MODULE) //0x00000268
             break;
-
+        /* FALLTHRU */
     case CMD_START_MODULE: //0x00000270
         pMod = sceKernelGetModuleFromUID(pModParams->modId); //0x00000270
         if (pMod == NULL && (pMod = sceKernelFindModuleByUID(pModParams->modId)) == NULL) //0x00000400
@@ -254,7 +254,7 @@ static s32 exe_thread(SceSize args, void *argp)
 
         if (status < SCE_ERROR_OK || pModParams->modeFinish == CMD_START_MODULE) //0x000002B4 & 0x000002C0
             break;
-
+        /* FALLTHRU */
     case CMD_STOP_MODULE: //0x000002C8
         if (pMod == NULL) { //0x000002C8
             pMod = sceKernelGetModuleFromUID(pModParams->modId);
@@ -279,7 +279,7 @@ static s32 exe_thread(SceSize args, void *argp)
 
         if (status < SCE_ERROR_OK || pModParams->modeFinish == CMD_STOP_MODULE) //0x0000030C & 0x00000318
             break;
-
+        /* FALLTHRU */
     case CMD_UNLOAD_MODULE: //0x00000320
         pMod = sceKernelGetModuleFromUID(pModParams->modId); //0x00000320
         if (pMod == NULL) { // 0x00000328
@@ -309,27 +309,21 @@ static s32 exe_thread(SceSize args, void *argp)
 }
 
 // 0x0000501C
-s32 ModuleMgrRebootPhase(SceSize argc, void *argp)
+s32 ModuleMgrRebootPhase()
 {
-    (void)argc;
-    (void)argp;
-
     return SCE_ERROR_OK;
 }
 
 // 0x00005024
-s32 ModuleMgrRebootBefore(SceSize argc, void *argp)
+s32 ModuleMgrRebootBefore()
 {
-    (void)argc;
-    (void)argp;
-
     return sceKernelSuspendThread(g_ModuleManager.threadId); //0x00005034
 }
 // 0x00005048
 /*
  * Create the work objects (threads,...) for the module manager.
  */
-s32 ModuleMgrInit(SceSize argc, void *argp)
+s32 ModuleMgrInit(s32 argc, void *argp)
 {
     (void)argc;
     (void)argp;

--- a/src/modulemgr/rebootModule.c
+++ b/src/modulemgr/rebootModule.c
@@ -148,7 +148,7 @@ s32 sceKernelRebootPhaseForKernel(s32 arg1, void *argp, s32 arg3, s32 arg4)
         if (GET_MCB_STATUS(pMod->status) != MCB_STATUS_STARTED || (pMod->status & SCE_MODULE_USER_MODULE)) //0x00004A58 - 0x00004B04
             continue;
 
-        pMod->moduleRebootPhase(arg1, (u32)argp, arg3, arg4); //0x00004B0C
+        pMod->moduleRebootPhase(arg1, argp, arg3, arg4); //0x00004B0C
 
         if (!sceKernelIsToolMode()) //0x00004B1C
             continue;
@@ -197,7 +197,7 @@ s32 sceKernelRebootBeforeForKernel(void *argp, s32 arg2, s32 arg3, s32 arg4)
         if (GET_MCB_STATUS(pMod->status) != MCB_STATUS_STARTED || (pMod->status & SCE_MODULE_USER_MODULE)) //0x00004C08,  0x00004CB0
             continue;
 
-        pMod->moduleRebootBefore((u32)argp, arg2, arg3, arg4); //0x00004CB8
+        pMod->moduleRebootBefore(argp, arg2, arg3, arg4); //0x00004CB8
     }
 
     status = ClearFreePartitionMemory(uidBlkId); // 0x00004C24 - 0x00004C60

--- a/src/modulemgr/rebootModule.c
+++ b/src/modulemgr/rebootModule.c
@@ -84,9 +84,11 @@ s32 sceKernelRebootBeforeForUser(void *arg)
             threadParams.stackMpid = SCE_KERNEL_PRIMARY_USER_PARTITION;
 
         pspSetGp(pMod->gpValue); //0x00004900
-
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
         pMod->userModThid = sceKernelCreateThread("SceModmgrRebootBefore", (SceKernelThreadEntry)pMod->moduleRebootBefore, priority,
             stackSize, threadMode | attr, &threadParams); //0x0000491C
+#pragma GCC diagnostic pop
 
         pspSetGp(oldGp);
 

--- a/src/syscon/syscon.c
+++ b/src/syscon/syscon.c
@@ -2043,7 +2043,7 @@ s32 sceSysconBatteryGetInfo(s32 *info)
 s32 sceSysconGetBattVolt(s32 *volt)
 {   
     u8 version =_sceSysconGetBaryonVersion() >> 16;
-    if ((version & 0xF0) != 0x29 &&
+    if ((version & 0xF0) != 0x20 &&
       (version & 0xFF) != 0x2A &&
       (version & 0xF0) != 0x30 &&
       (version & 0xF0) != 0x40)
@@ -2059,7 +2059,7 @@ s32 sceSysconGetBattVolt(s32 *volt)
 s32 sceSysconGetBattVoltAD(s32 *volt1, s32 *volt2)
 {
     u8 version = _sceSysconGetBaryonVersion() >> 16;
-    if ((version & 0xF0) != 0x29 &&
+    if ((version & 0xF0) != 0x20 &&
       (version & 0xFF) != 0x2A &&
       (version & 0xF0) != 0x30 &&
       (version & 0xF0) != 0x40)
@@ -2172,7 +2172,7 @@ s32 sceSysconBatteryGetChargeTime(s32 *time)
 s32 _sceSysconBatteryCommon(u32 cmd, s32 *ptr)
 {
     u32 version = _sceSysconGetBaryonVersion() >> 16;
-    if ((version & 0xF0) == 0x29 ||
+    if ((version & 0xF0) == 0x20 ||
      (version & 0xFF) == 0x2A ||
      (version & 0xF0) == 0x30 ||
      (version & 0xF0) == 0x40)

--- a/src/syscon/syscon.c
+++ b/src/syscon/syscon.c
@@ -958,7 +958,7 @@ s32 _sceSysconCommonRead(s32 *ptr, s32 cmd)
     return 0;
 }
 
-s32 _sceSysconModuleStart(s32 argc __attribute__((unused)), void *argp __attribute__((unused)))
+s32 _sceSysconModuleStart(SceSize argSize __attribute__((unused)), const void *argBlock __attribute__((unused)))
 {
     sceSysconInit();
     return 0;

--- a/src/syscon/syscon.c
+++ b/src/syscon/syscon.c
@@ -138,7 +138,7 @@ SceSysconPacket g_GetStatus2Cmd;
 
 SceSyscon g_Syscon;
 
-s32 _sceSysconModuleRebootBefore(void)
+s32 _sceSysconModuleRebootBefore(void *arg0 __attribute__((unused)), s32 arg1 __attribute__((unused)), s32 arg2 __attribute__((unused)), s32 arg3 __attribute__((unused)))
 {
     if (g_Syscon.unk376 != 0) {
         sceSyscon_driver_765775EB(0);

--- a/src/syscon/syscon.c
+++ b/src/syscon/syscon.c
@@ -2043,8 +2043,10 @@ s32 sceSysconBatteryGetInfo(s32 *info)
 s32 sceSysconGetBattVolt(s32 *volt)
 {   
     u8 version =_sceSysconGetBaryonVersion() >> 16;
-    if ((version & 0xF0) != 0x20 &&
-      (version & 0xFF) != 0x2A &&
+    /* Note Sony also does the following tautological check:
+         if ((version & 0xF0) == 0x29)
+    */
+    if ((version & 0xFF) != 0x2A &&
       (version & 0xF0) != 0x30 &&
       (version & 0xF0) != 0x40)
         return 0x80000004;
@@ -2059,8 +2061,10 @@ s32 sceSysconGetBattVolt(s32 *volt)
 s32 sceSysconGetBattVoltAD(s32 *volt1, s32 *volt2)
 {
     u8 version = _sceSysconGetBaryonVersion() >> 16;
-    if ((version & 0xF0) != 0x20 &&
-      (version & 0xFF) != 0x2A &&
+    /* Note Sony also does the following tautological check:
+         if ((version & 0xF0) == 0x29)
+    */
+    if ((version & 0xFF) != 0x2A &&
       (version & 0xF0) != 0x30 &&
       (version & 0xF0) != 0x40)
         return 0x80000004;
@@ -2172,8 +2176,10 @@ s32 sceSysconBatteryGetChargeTime(s32 *time)
 s32 _sceSysconBatteryCommon(u32 cmd, s32 *ptr)
 {
     u32 version = _sceSysconGetBaryonVersion() >> 16;
-    if ((version & 0xF0) == 0x20 ||
-     (version & 0xFF) == 0x2A ||
+    /* Note Sony also does the following tautological check:
+         if ((version & 0xF0) == 0x29)
+    */
+    if ((version & 0xFF) == 0x2A ||
      (version & 0xF0) == 0x30 ||
      (version & 0xF0) == 0x40)
         return 0x80000004;

--- a/src/sysmem/kdebug.c
+++ b/src/sysmem/kdebug.c
@@ -321,6 +321,8 @@ int kprnt(short *arg0, const char *fmt, va_list ap, int userMode)
                 case 'D':
                     // 100D8
                     attr |= 1;
+                    /* FALLTHRU */
+
                 case 'd':
                 case 'i':
                     // 100DC
@@ -355,6 +357,8 @@ int kprnt(short *arg0, const char *fmt, va_list ap, int userMode)
 
                 case 'O':
                     attr |= 1;
+                    /* FALLTHRU */
+
                 case 'o':
                     // 104C0
                     if ((attr & 2) == 0)
@@ -375,6 +379,8 @@ int kprnt(short *arg0, const char *fmt, va_list ap, int userMode)
                 case 'U':
                     // 10514
                     attr |= 1;
+                    /* FALLTHRU */
+
                 case 'u':
                     // 10518
                     if ((attr & 2) == 0)
@@ -395,6 +401,8 @@ int kprnt(short *arg0, const char *fmt, va_list ap, int userMode)
                 case 'X':
                     // 10558
                     hexNumChars = "0123456789ABCDEF";
+                    /* FALLTHRU */
+
                 case 'x':
                     // 10564
                     base = 16;

--- a/src/sysmem/sysclib.c
+++ b/src/sysmem/sysclib.c
@@ -549,6 +549,8 @@ int prnt(prnt_callback cb, void *ctx, const char *fmt, va_list args)
                     if (numAlign >= 0)
                         continue;
                     numAlign = -numAlign;
+                    /* FALLTHRU */
+
                 case '-':
                     // DB70
                     flag |= 0x10;
@@ -612,6 +614,8 @@ int prnt(prnt_callback cb, void *ctx, const char *fmt, va_list args)
                 case 'D':
                     // DC64
                     flag |= 1;
+                    /* FALLTHRU */
+
                 case 'd':
                 case 'i': {
                     // DC70
@@ -662,6 +666,8 @@ int prnt(prnt_callback cb, void *ctx, const char *fmt, va_list args)
                 case 'O':
                     // DFE0
                     flag |= 1;
+                    /* FALLTHRU */
+
                 case 'o':
                     // DFEC
                     base = 8;
@@ -670,6 +676,8 @@ int prnt(prnt_callback cb, void *ctx, const char *fmt, va_list args)
                 case 'U':
                     // E028
                     flag |= 1;
+                    /* FALLTHRU */
+
                 case 'u':
                     // E034
                     base = 10;
@@ -678,6 +686,8 @@ int prnt(prnt_callback cb, void *ctx, const char *fmt, va_list args)
                 case 'X':
                     // E044
                     ciphers = "0123456789ABCDEF";
+                    /* FALLTHRU */
+
                 case 'x':
                     // E050
                     base = 16;
@@ -1191,11 +1201,15 @@ char *strncpy(char *dest, const char *src, int n)
     return dest;
 }
 
-u32 strnlen(const char *s, int maxlen)
+u32 strnlen(const char *s, u32 maxlen)
 {
-    int len = 0;
+    u32 len = 0;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull-compare"
     if (s == NULL || maxlen == 0)
         return 0;
+#pragma GCC diagnostic pop
+
     // E9A4
     while (*(s++) != '\0')
     {

--- a/src/sysmem/sysmem.c
+++ b/src/sysmem/sysmem.c
@@ -81,8 +81,9 @@ void SetMemoryPartitionTable(SysMemConfig *config, SceSysmemPartTable *table);
 s32 suspendSysmem(int unk __attribute__((unused)), void *param __attribute__((unused)));
 s32 resumeSysmem(int unk __attribute__((unused)), void *param __attribute__((unused)));
 
-int SysMemInit(int args __attribute__((unused)), SysMemConfig *config)
+int SysMemInit(SceSize argSize __attribute__((unused)), const void *argBlock)
 {
+    SysMemConfig *config = (SysMemConfig *)argBlock;
     SceSysmemMemoryPartition mainPart;
     SceSysmemPartTable table;
     sceKernelRegisterDebugPutcharByBootloader(config->debugPutchar);

--- a/src/systimer/systimer.c
+++ b/src/systimer/systimer.c
@@ -219,7 +219,7 @@ s32 SysTimerInit(s32 argc __attribute__((unused)), void *argp __attribute__((unu
     return SCE_ERROR_OK;
 }
 
-s32 SysTimerEnd(s32 argc __attribute__((unused)), void *argp __attribute__((unused)))
+s32 SysTimerEnd()
 {
     s32 oldIntr = sceKernelCpuSuspendIntr();
     

--- a/src/systimer/systimer.c
+++ b/src/systimer/systimer.c
@@ -219,7 +219,7 @@ s32 SysTimerInit(SceSize argSize __attribute__((unused)), const void *argBlock _
     return SCE_ERROR_OK;
 }
 
-s32 SysTimerEnd()
+s32 SysTimerEnd(void *arg0 __attribute__((unused)), s32 arg1 __attribute__((unused)), s32 arg2 __attribute__((unused)), s32 arg3 __attribute__((unused)))
 {
     s32 oldIntr = sceKernelCpuSuspendIntr();
     

--- a/src/systimer/systimer.c
+++ b/src/systimer/systimer.c
@@ -194,7 +194,7 @@ static s32 _sceSTimerGetCount(SceSysTimer *timer);
 static s32 suspendSTimer(s32 unk __attribute__((unused)), void *param __attribute__((unused)));
 static s32 resumeSTimer(s32 unk __attribute__((unused)), void *param __attribute__((unused)));
 
-s32 SysTimerInit(s32 argc __attribute__((unused)), void *argp __attribute__((unused)))
+s32 SysTimerInit(SceSize argSize __attribute__((unused)), const void *argBlock __attribute__((unused)))
 {
     s32 oldIntr = sceKernelCpuSuspendIntr();
     

--- a/src/usersystemlib/usersystemlib.c
+++ b/src/usersystemlib/usersystemlib.c
@@ -31,7 +31,7 @@ SceThread *g_thread; // 2bc0
 static s32 g_cmdList[CMD_LIST_SIZE]; // 2c00
 
 // module_start
-s32 _UsersystemLibInit(SceSize argc __attribute__((unused)), void *argp __attribute__((unused)))
+s32 _UsersystemLibInit(s32 argc __attribute__((unused)), void *argp __attribute__((unused)))
 {
     // InterruptManager_EEE43F47
     sceKernelRegisterUserSpaceIntrStack(

--- a/src/usersystemlib/usersystemlib.c
+++ b/src/usersystemlib/usersystemlib.c
@@ -31,7 +31,7 @@ SceThread *g_thread; // 2bc0
 static s32 g_cmdList[CMD_LIST_SIZE]; // 2c00
 
 // module_start
-s32 _UsersystemLibInit(s32 argc __attribute__((unused)), void *argp __attribute__((unused)))
+s32 _UsersystemLibInit(SceSize argSize __attribute__((unused)), const void *argBlock __attribute__((unused)))
 {
     // InterruptManager_EEE43F47
     sceKernelRegisterUserSpaceIntrStack(


### PR DESCRIPTION
It is not currently possible to compile uOFW with a recent psp-toolchain as it uses GCC 9 instead of GCC 4 and many more warnings are thrown.
## Description
Most of the fixes are trivial things like lack of `if` indentation, lack of `switch/case` `FALLTHRU` comments, and function signatures not matching.

There were a few cases where I was unsure how to actually fix the problem at its root cause and instead wrapped the offending line with GCC pragmas to silence the warning. I tried to do this as sparingly as possible and would welcome feedback on a better way to accomplish this.

The GCC 9 warnings _did_ find an actual bug in `src/loadcore/loadcore.c:1745` where a `continue;` statement would always be taken, negating the rest of a very large for loop. _(insert warning about naked if statements here)_

## How Has This Been Tested?
I regret that I am not currently able to test this on a PSP.