### PR TITLE
Controller service: Add comments detailing SYSCON retrieved button states.

### DIFF
--- a/include/ctrl.h
+++ b/include/ctrl.h
@@ -136,61 +136,63 @@ typedef struct {
  */
 enum SceCtrlPadButtons {
     /** Select button. */
-    SCE_CTRL_SELECT         = 0x1,
+    SCE_CTRL_SELECT         = 0x00000001,
     /** DS3 L3 button. */
-    SCE_CTRL_L3             = 0x2,
+    SCE_CTRL_L3             = 0x00000002,
     /** DS3 R3 button. */
-    SCE_CTRL_R3             = 0x4,
+    SCE_CTRL_R3             = 0x00000004,
     /** Start button. */
-    SCE_CTRL_START          = 0x8,
+    SCE_CTRL_START          = 0x00000008,
     /** Up D-Pad button. */
-    SCE_CTRL_UP             = 0x10,
+    SCE_CTRL_UP             = 0x00000010,
     /** Right D-Pad button. */
-    SCE_CTRL_RIGHT          = 0x20,
+    SCE_CTRL_RIGHT          = 0x00000020,
     /** Down D-Pad button. */
-    SCE_CTRL_DOWN           = 0x40,
+    SCE_CTRL_DOWN           = 0x00000040,
     /** Left D-Pad button. */
-    SCE_CTRL_LEFT           = 0x80,
+    SCE_CTRL_LEFT           = 0x00000080,
     /** Left trigger. This accounts for the DS3 L2 trigger as well. */
-    SCE_CTRL_LTRIGGER       = 0x100,
+    SCE_CTRL_LTRIGGER       = 0x00000100,
     /** Right trigger. This accounts for the DS3 R2 trigger as well. */
-    SCE_CTRL_RTRIGGER       = 0x200,
+    SCE_CTRL_RTRIGGER       = 0x00000200,
     /** DS3 L1 trigger. */
-    SCE_CTRL_L1TRIGGER      = 0x400,
+    SCE_CTRL_L1TRIGGER      = 0x00000400,
     /** DS3 R1 trigger. */
-    SCE_CTRL_R1TRIGGER      = 0x800,
+    SCE_CTRL_R1TRIGGER      = 0x00000800,
     /** Triangle button. */
-    SCE_CTRL_TRIANGLE       = 0x1000,
+    SCE_CTRL_TRIANGLE       = 0x00001000,
     /** Circle button. */
-    SCE_CTRL_CIRCLE         = 0x2000,
+    SCE_CTRL_CIRCLE         = 0x00002000,
     /** Cross button. */
-    SCE_CTRL_CROSS          = 0x4000,
+    SCE_CTRL_CROSS          = 0x00004000,
     /** Square button. */
-    SCE_CTRL_SQUARE         = 0x8000,
+    SCE_CTRL_SQUARE         = 0x00008000,
     /** 
      * If this bit is set, then controller input is being intercepted by the 
      * system software or another application.  For example, this is the case 
      * when the PSP's HOME menu is being shown. 
      */
-    SCE_CTRL_INTERCEPTED    = 0x10000,
+    SCE_CTRL_INTERCEPTED    = 0x00010000,
     /** Hold button. */
-    SCE_CTRL_HOLD           = 0x20000,
+    SCE_CTRL_HOLD           = 0x00020000,
     /** W-LAN switch up. */
-    SCE_CTRL_WLAN_UP        = 0x40000,
+    SCE_CTRL_WLAN_UP        = 0x00040000,
     /** Remote hold position. */
-    SCE_CTRL_REMOTE         = 0x80000,
+    SCE_CTRL_REMOTE         = 0x00080000,
     /** Volume up button. */
-    SCE_CTRL_VOLUP          = 0x100000,
+    SCE_CTRL_VOLUP          = 0x00100000,
     /** Volume down button. */
-    SCE_CTRL_VOLDOWN        = 0x200000,
+    SCE_CTRL_VOLDOWN        = 0x00200000,
     /** Screen button. */
-    SCE_CTRL_SCREEN         = 0x400000,
+    SCE_CTRL_SCREEN         = 0x00400000,
     /** Music Note button. */
-    SCE_CTRL_NOTE           = 0x800000,   	
+    SCE_CTRL_NOTE           = 0x00800000,   	
     /** Disc present. */
-    SCE_CTRL_DISC           = 0x1000000,
+    SCE_CTRL_DISC           = 0x01000000,
     /** Memory stick present. */
-    SCE_CTRL_MS             = 0x2000000,
+    SCE_CTRL_MS             = 0x02000000,
+    SCE_CTRL_UNK_10000000   = 0x10000000,
+    SCE_CTRL_UNK_20000000   = 0x20000000,
 };
 
 /** Controller input modes. */

--- a/src/ctrl/ctrl.c
+++ b/src/ctrl/ctrl.c
@@ -163,6 +163,29 @@ SCE_SDK_VERSION(SDK_VERSION);
 //SCE_CTRL_MS | SCE_CTRL_DISC | SCE_CTRL_REMOTE | SCE_CTRL_WLAN_UP | SCE_CTRL_HOLD | ?
 #define CTRL_HARDWARE_IO_BUTTONS                (0x3B0E0000)
 
+/*
+ * Represents the [user mode] buttons retrieved from SYSCON for which their button pressed state is represented
+ * in negative logic. Since the controller service represents the pressed state of a button in positive logic,
+ * the corresponding bits for these buttons need to be flipped before storing them in our internal controller
+ * buffers.
+ */
+#define CTRL_SYSCON_USER_MODE_BUTTONS_NEGATIVE_LOGIC    (SCE_CTRL_SELECT | SCE_CTRL_START | \
+                                                         SCE_CTRL_UP | SCE_CTRL_RIGHT | SCE_CTRL_DOWN | SCE_CTRL_LEFT | \
+                                                         SCE_CTRL_LTRIGGER | SCE_CTRL_RTRIGGER | \
+                                                         SCE_CTRL_TRIANGLE | SCE_CTRL_CIRCLE | SCE_CTRL_CROSS | SCE_CTRL_SQUARE | \
+                                                         SCE_CTRL_INTERCEPTED | SCE_CTRL_HOLD | SCE_CTRL_WLAN_UP)
+/*
+ * Represents the [kernel mode] buttons retrieved from SYSCON for which their button pressed state is represented
+ * in negative logic. Since the controller service represents the pressed state of a button in positive logic,
+ * the corresponding bits for these buttons need to be flipped before storing them in our internal controller
+ * buffers.
+ */
+#define CTRL_SYSCON_KERNEL_MODE_BUTTONS_NEGATIVE_LOGIC  (CTRL_SYSCON_USER_MODE_BUTTONS_NEGATIVE_LOGIC | \
+                                                         SCE_CTRL_VOLUP | SCE_CTRL_VOLDOWN | SCE_CTRL_SCREEN | SCE_CTRL_NOTE | \
+                                                         SCE_CTRL_UNK_20000000)
+
+
+
 /* Controller buffer read modes. */
 enum SceCtrlReadBufferModes {
     PEEK_BUFFER_POSITIVE = 0,
@@ -1430,7 +1453,24 @@ static s32 _sceCtrlSysconCmdIntr1(SceSysconPacket *sysPacket, void *argp)
                           | ((sysPacket->rx[PSP_SYSCON_RX_DATA(1)] & 6) << 7)
                           | ((sysPacket->rx[PSP_SYSCON_RX_DATA(0)] & 0xF) << 4)
                           | (sysPacket->rx[PSP_SYSCON_RX_DATA(1)] & 9)) 
-                    ^ 0x20F7F3F9;
+                    /*
+                     * The PSP's hardware buttons are [active low], in other words, a SYSCON sent button bit
+                     * is 0 if the button is currently being pressed. If the bit is 1, then the button
+                     * is not being pressed.
+                     *
+                     * By default, the controller service represents a button pressed state in positive logic,
+                     * that is if a button is currently being pressed, its corresponding bit in the internal
+                     * controller buffers will be set to 1. Consequently, the button bit is set to 0 if the
+                     * button is not currently being pressed.
+                     *
+                     * As such, we need to flip the button bits retrieved from SYSCON which are represented in
+                     * negative logic.
+                     * 
+                     * Note that some controller connection states like [SCE_CTRL_MS] are [active high]
+                     * and thus we do not need to flip such bits.
+                     *
+                     */
+                    ^ CTRL_SYSCON_KERNEL_MODE_BUTTONS_NEGATIVE_LOGIC;
             }
         }
         else {
@@ -1439,7 +1479,21 @@ static s32 _sceCtrlSysconCmdIntr1(SceSysconPacket *sysPacket, void *argp)
                        | ((sysPacket->rx[PSP_SYSCON_RX_DATA(1)] & 0x6) << 7)
                        | ((sysPacket->rx[PSP_SYSCON_RX_DATA(0)] & 0xF) << 4)
                        | (sysPacket->rx[PSP_SYSCON_RX_DATA(1)] & 0x9)) 
-                    ^ 0x7F3F9) 
+
+                    /*
+                     * The PSP's buttons are [active low], in other words, a SYSCON sent button bit
+                     * is 0 if the button is currently being pressed. If the bit is 1, then the button
+                     * is not being pressed.
+                     * 
+                     * By default, the controller service represents a button pressed state in positive logic,
+                     * that is if a button is currently being pressed, its corresponding bit in the internal
+                     * controller buffers will be set to 1. Consequently, the button bit is set to 0 if the
+                     * button is not currently being pressed.
+                     * 
+                     * As such, we need to invert the user mode button bits retrieved from SYSCON.
+                     * 
+                     */
+                    ^ CTRL_SYSCON_USER_MODE_BUTTONS_NEGATIVE_LOGIC)
                     | (g_ctrl.rawButtons & 0xFFF00000);
         }
         g_ctrl.rawButtons = curButtons;

--- a/src/ctrl/ctrl.c
+++ b/src/ctrl/ctrl.c
@@ -1468,7 +1468,6 @@ static s32 _sceCtrlSysconCmdIntr1(SceSysconPacket *sysPacket, void *argp)
                      * 
                      * Note that some controller connection states like [SCE_CTRL_MS] are [active high]
                      * and thus we do not need to flip such bits.
-                     *
                      */
                     ^ CTRL_SYSCON_KERNEL_MODE_BUTTONS_NEGATIVE_LOGIC;
             }
@@ -1491,7 +1490,6 @@ static s32 _sceCtrlSysconCmdIntr1(SceSysconPacket *sysPacket, void *argp)
                      * button is not currently being pressed.
                      * 
                      * As such, we need to invert the user mode button bits retrieved from SYSCON.
-                     * 
                      */
                     ^ CTRL_SYSCON_USER_MODE_BUTTONS_NEGATIVE_LOGIC)
                     | (g_ctrl.rawButtons & 0xFFF00000);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds comments to the controller service detailing that the PSP hardware buttons are "active low" and as such their button pressed states when retrieved from SYSCON are represented in negative logic.
