### PR TITLE
Add the chnnlsv module to the global makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-MODULES=debug audio clockgen codec ctrl exceptionman ge init interruptman \
+MODULES=debug audio chnnlsv clockgen codec ctrl exceptionman ge init interruptman \
 iofilemgr led libatrac3plus loadcore loadexec mediaman me_wrapper modulemgr \
 syscon sysmem systimer usersystemlib wlanfirm
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds the reverse-engineered `chnnlsv` module (responsible for savedata encryption/decryption) to the global makefile.

## Motivation and Context
Adding it to the global makefile makes the module part of our CI.

## How Has This Been Tested?
The CI ran successfully with the module included.
