### PR TITLE
Fix SCE_MODULE_STOP macro.

### DIFF
--- a/include/common/module.h
+++ b/include/common/module.h
@@ -144,7 +144,7 @@ enum SceModulePrivilegeLevel {
 #define SCE_MODULE_REBOOT_BEFORE(name)  int module_reboot_before(void *arg0, s32 arg1, s32 arg2, s32 arg3) __attribute__((alias(name)))
 #define SCE_MODULE_REBOOT_BEFORE_FOR_USER(name)  int module_reboot_before(SceSize arglen, void *argp) __attribute__((alias(name)))
 #define SCE_MODULE_REBOOT_PHASE(name)   int module_reboot_phase(s32 arg1, void *arg2, s32 arg3, s32 arg4) __attribute__((alias(name)))
-#define SCE_MODULE_STOP(name)           int module_stop(void) __attribute__((alias(name)))
+#define SCE_MODULE_STOP(name)           int module_stop(SceSize argSize, const void *argBlock) __attribute__((alias(name)))
 
 #define SCE_MODULE_INFO(name, attributes, majorVersion, minorVersion) \
     __asm__ (                                                       \

--- a/src/libatrac3plus/libatrac3plus.c
+++ b/src/libatrac3plus/libatrac3plus.c
@@ -595,7 +595,7 @@ int sceAtracStartEntry(SceSize argSize __attribute__((unused)), const void *argB
     return (sceAtracReinit(2, 2) < 0);
 }
 
-int sceAtracEndEntry(void)
+int sceAtracEndEntry(SceSize argSize __attribute__((unused)), const void *argBlock __attribute__((unused)))
 {
     if (g_edramAddr != -1)
         sceAudiocodecReleaseEDRAM(&g_atracIds[0].codec);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes our `SCE_MODULE_STOP` macro so that it now uses the correct function signature for `module_stop()`  (the module stop entry point).

## Motivation and Context
Closes https://github.com/uofw/uofw/issues/88.

## How Has This Been Tested?
Verified that our modules still compile.
