### PR TITLE
CI: Update consumed toolchain package to use psp-gcc 9 etc...

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,20 +10,20 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install doxygen
-          wget https://github.com/uofw/artifacts/releases/download/psp-toolchain-02-2021/psptoolchain.deb
+          wget https://github.com/uofw/artifacts/releases/latest/download/psptoolchain.deb
           sudo dpkg --install psptoolchain.deb
       - name: Build project
         run: |
-          source /etc/profile.d/psptoolchain.sh
+          . /etc/profile.d/psptoolchain.sh
           make -k
       - name: Build documentation
-        run : |
+        run: |
           mkdir github-pages
           cd github-pages
           doxygen ../docs/Doxyfile
       - name: Deploy documentation
         if: github.ref == 'refs/heads/master'
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@4.1.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install doxygen
-          wget http://www.mirari.fr/VmX0 -O psptoolchain.deb
+          wget https://github.com/uofw/artifacts/releases/download/psp-toolchain-02-2021/psptoolchain.deb -O psptoolchain.deb
           sudo dpkg --install psptoolchain.deb
       - name: Build project
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install doxygen
-          wget https://github.com/uofw/artifacts/releases/download/psp-toolchain-02-2021/psptoolchain.deb -O psptoolchain.deb
+          wget https://github.com/uofw/artifacts/releases/download/psp-toolchain-02-2021/psptoolchain.deb
           sudo dpkg --install psptoolchain.deb
       - name: Build project
         run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR replaces the outdated psp-toolchain (i.e. psp-gcc version 4) used in our CI with an updated toolchain package (i.e. psp-gcc 9) built in early February this year directly from the [psp-toolchain](https://github.com/pspdev/psptoolchain) repo.

As outlined in issue #81, I've wanted to wait and see if the psp-toolchain team could provide binaries directly so that we will always use an up-to-date toolchain, but it doesn't look like progress will happen on this anytime soon. See https://github.com/pspdev/psptoolchain/pull/145 for more details and progress.

In the meantine, we have to deal with a heavily outdated psp-gcc version which requires us to [write additional code in order to have the CI succeed](https://github.com/uofw/uofw/pull/82/commits/33c614beb1f9ebd20825918b5cfd777757c6f720). As such, I think it is best if we just go ahead here and update the toolchain in the CI with a freshly built one even if we'll have to update it manually if necessary.

The new toolchain package is located in the [uofw/artifacts](https://github.com/uofw/artifacts) repo which has been created to contain binaries required for our CI.

Once the toolchain team has set up a system where we can always pull an up-to-date toolchain from them, we should update our CI to do just that.

## Motivation and Context
Closes #81.

## How Has This Been Tested?
CI still works.

@artart78 @John-K @joel16 FYI.
