### PR TITLE
Update gh-actions to use latest Ubuntu environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description
Ubuntu 16.04 environment was [recently removed from Github](https://github.com/actions/virtual-environments/issues/3287). This PR updates our github-actions script to use the latest Ubuntu environment available (currently Ubuntu 20.04).

## Motivation and Context
Fixes Github actions.