### PR TITLE
Fixing RE errors in PspUncompress()

### DIFF
--- a/src/loadcore/loadelf.c
+++ b/src/loadcore/loadelf.c
@@ -1006,7 +1006,6 @@ static s32 PspUncompress(u8 *modBuf, SceLoadCoreExecFileInfo *execInfo,
                          u32 *newSize) 
 {   
     PspHeader *header = (PspHeader *)modBuf;
-    s8 *buf = NULL;
     u8 checkCompAttr;
     u8 decryptMode;
     s32 status;

--- a/src/loadcore/loadelf.h
+++ b/src/loadcore/loadelf.h
@@ -60,8 +60,8 @@ enum SceExecFileDecryptMode {
     DECRYPT_MODE_UNKNOWN_21                 = 21, // 0x15
     /** SCE_MODULE_APP module. APP demo exec? */
     DECRYPT_MODE_UNKNOWN_22                 = 22, // 0x16
-    /** SCE_MODULE_USER module with secure install ID. */
-    DECRYPT_MODE_UNKNOWN_23                 = 23, // 0x17
+    /** NPDRM user module with secure install ID. */
+    DECRYPT_MODE_USER_NPDRM                 = 23, // 0x17
     /**
      * Game patch (PBOOT.PBP) for retail console (eg. SOCOM FTB 3). 
      * This module can be decrypted with any PSP device.


### PR DESCRIPTION
Small PR to fix a bunch of reverse-engineering errors in `loadelf.c` with faulty logic for decompressing the module data with `sceKernelGzipDecompress()` or `UtilsForKernel_6C6887EE()`. 

The ~PSP header `decryptMode` member was read from the module buffer *after* the data was decrypted. At this point, the ~PSP header no longer exists, the buffer only contains the plain ELF/PRX data. Hence the need to save the `decryptMode` in a variable before decrypting the module data.