### PR TITLE
Resolve modulemgr NID 0x1D4042A5 (module_text_checksum)

### DIFF
--- a/include/loadcore.h
+++ b/include/loadcore.h
@@ -805,8 +805,12 @@ typedef struct SceModule {
     u32 segmentChecksum; //216
     /** TEXT segment checksum of the module. */
     u32 textSegmentChecksum; //220
-    /** Unknown. */
-    u32 unk224; //224
+    /** 
+     * Whether to compute the text segment checksum before starting the module (see prologue).
+     * If non-zero, the text segment checksum will be computed after the module's resident libraries 
+     * have been registered, and its stub libraries have been linked.
+     */
+    u32 computeTextSegmentChecksum; //224
 } SceModule; //size = 228
 
 /**

--- a/include/modulemgr_nids.h
+++ b/include/modulemgr_nids.h
@@ -23,7 +23,7 @@ extern "C" {
 #define NID_MODULE_STOP_THREAD_PARAM                        0xCF0CC697
 #define NID_MODULE_INFO                                     0xF01D73A7
 #define NID_MODULE_SDK_VERSION                              0x11B97506
-#define NID_1D4042A5                                        0x1D4042A5
+#define NID_MODULE_TEXT_CHECKSUM                            0x1D4042A5
 
 
 #ifdef  __cplusplus

--- a/src/kd/loadcore/module.c
+++ b/src/kd/loadcore/module.c
@@ -521,7 +521,7 @@ static SceUID module_do_initialize(SceSysmemUidCB *cb, SceSysmemUidCB *uidWithFu
     mod->bssSize = 0; //0x0000728C
     mod->segmentChecksum = 0; //0x00007290
     mod->textSegmentChecksum = 0; //0x00007294
-    mod->unk224 = 0; //0x00007298
+    mod->computeTextSegmentChecksum = 0; //0x00007298
     mod->status = 0; //0x000072A4
     mod->next = NULL; //0x000072A8
     mod->attribute = 0; //0x000072AC

--- a/src/kd/modulemgr/modulemgr.c
+++ b/src/kd/modulemgr/modulemgr.c
@@ -146,6 +146,7 @@ static s32 _UnloadModule(SceModule *pMod)
         sceKernelFreePartitionMemory(pMod->moduleBlockId); //0x00000168
 
     sceKernelDeleteModule(pMod); //0x00000158
+    // uOFW: here, Sony forgot to reset g_ModuleManager.pModule to NULL when it's equal to pMod
 
     return SCE_ERROR_OK;
 }
@@ -1448,9 +1449,9 @@ static s32 _ProcessModuleExportEnt(SceModule *pMod, SceResidentLibraryEntryTable
     //0x00007A04 - 0x00007A6C
     for (i = 0; i < pLib->vStubCount; i++) {
         switch (pLib->entryTable[pLib->stubCount + i]) {
-        case NID_1D4042A5: // 0x00007A48
+        case NID_MODULE_TEXT_CHECKSUM: // 0x00007A48
             g_ModuleManager.pModule = pMod; // 0x00007B64
-            pMod->unk224 = *(u32 *)(pLib->entryTable[2 * pLib->stubCount + pLib->vStubCount + i]); // 0x00007B70
+            pMod->computeTextSegmentChecksum = *(u32 *)(pLib->entryTable[2 * pLib->stubCount + pLib->vStubCount + i]); // 0x00007B70
             break;
         case NID_MODULE_INFO: // 0x00007AB8
             break;
@@ -1684,7 +1685,7 @@ static s32 _PrologueModule(SceModuleMgrParam *pModParams, SceModule *pMod)
     }
 
     pMod->segmentChecksum = sceKernelSegmentChecksum(pMod); // 0x00008198
-    if (pMod->unk224 != 0) { // 0x000081A4
+    if (pMod->computeTextSegmentChecksum != 0) { // 0x000081A4
         u32 sum = 0;
         u32 *pTextSegment = (u32 *)pMod->segmentAddr[0];
         u32 i;

--- a/src/kd/modulemgr/modulemgr_int.h
+++ b/src/kd/modulemgr/modulemgr_int.h
@@ -65,6 +65,7 @@ typedef struct {
     void *unk24;
     u32 unk28;
     s32(*npDrmGetModuleKeyFunction)(SceUID fd, void *, void *); // 32
+    /** Module whose text segment checksum can be checked with sceKernelCheckTextSegment (user). */
     SceModule *pModule;
 } SceModuleManagerCB;
 


### PR DESCRIPTION
Small PR that adds the resolved NID `0x1D4042A5` for `module_text_checksum`.
Thanks to that, the `SceModule` structure is now fully figured out.

This variable can be exported, and set to a non-zero value by a module, to indicate the checksum of the `.text` section must be computed upon loading the module (see [_PrologueModule](https://github.com/uofw/uofw/blob/85b85a19dd8fe5cc69e48d44cf9556ec8ede0628/src/kd/modulemgr/modulemgr.c#L1660) function). Otherwise the module's `textSegmentChecksum` (`SceModule`) is always set to 0. Then the user *can* check whether the contents of the `.text` section was somehow altered by calling the user-exported function `sceKernelCheckTextSegment()`. It's worth noting only the checksum of the module that was loaded last can be checked this way (iff `module_text_checksum` was exported).

On a side note, I think we should really normalize the line-endings at some point (ie. use only LF, and add a .gitattributes file) as both styles are used (mostly CRLF, and LF in some files). Coming up-next in multiple PRs: kirk/psp headers, fully working amctrl, psheet, and mesgled (still gotta extract all the tags/keys for 03g+). Other WIP modules I'm onto: memab (adhoc encryption module), memlmd, and iofilemgr_dnas (PGD files IO driver).

## How Has This Been Tested?
Successfully built the uOFW modules with the changes.
