### PR TITLE
Minor assembly changes (should be a no-op)

### DIFF
--- a/include/common/inline.h
+++ b/include/common/inline.h
@@ -48,7 +48,7 @@ inline static void pspCache(char op, const void *ptr)
 
 inline static void pspBreak(s32 op)
 {
-    asm __volatile__ ("break %0" : : "ri" (op));
+    asm __volatile__ ("break 0,%0" : : "ri" (op));
 }
 
 inline static void pspHalt(void)

--- a/src/kd/exceptionman/excep.S
+++ b/src/kd/exceptionman/excep.S
@@ -381,8 +381,8 @@ loc_000004CC:
     nop        
 
 loc_000004DC:
-    break      0x20000
+    break      0x080, 0x000  # 0x20000
 
 loc_000004E0:
-    break      0x20000
+    break      0x080, 0x000  # 0x20000
 

--- a/src/kd/init/init_asm.S
+++ b/src/kd/init/init_asm.S
@@ -24,7 +24,7 @@ loop2:
 	sw         $zr, 0($v0) # do { *origAddr = 0; }
 	bne        $t0, $v0, loop2 # while (origAddr++ != maxWordAddr);
 	addiu      $v0, $v0, 4
-	break      0x0
+	break
     .end initClearMem
 
 

--- a/src/kd/interruptman/start.S
+++ b/src/kd/interruptman/start.S
@@ -683,7 +683,7 @@ loc_08D8:
 
 loc_00000914:
     j          loc_00000914
-    break      0xFFF
+    break      0x003, 0x3FF  # (0x00FFF)
 
     .globl sub_091C
 sub_091C:
@@ -1114,7 +1114,7 @@ mod_0E50:
 
 loc_00000E98:
     j          loc_00000E98
-    break      0xFFE
+    break      0x003, 0x3FE  # (0x00FFE)
 
     # OHNOES alignment :O :O
     nop

--- a/src/kd/loadcore/interruptController.S
+++ b/src/kd/loadcore/interruptController.S
@@ -50,7 +50,7 @@ loadCoreCpuResumeIntr:
 
     .ent sub_00003D84
 sub_00003D84:
-    break      0x0
+    break
     j          sub_00003D84
     nop
     .end sub_00003D84

--- a/src/kd/loadcore/loadcore_asm.S
+++ b/src/kd/loadcore/loadcore_asm.S
@@ -32,7 +32,7 @@ loop2:		# Refs: 0x0000001C
 	sw         $zr, 0($v0) # do { *origAddr = 0; }
 	bne        $t0, $v0, loop2 # while (origAddr++ != maxWordAddr);
 	addiu      $v0, $v0, 4
-	break      0x0
+	break
     .end loadCoreClearMem
 
 ##
@@ -62,7 +62,7 @@ sceLoadCorePrimarySyscallHandler:
 	sw         $v1, 20($v0) # Save COP 1's control register 31
 	cfc0       $v1, COP0_CTRL_V0 # Save COP 0's control register 4
 	sw         $v1, 24($v0)
-	break      0x10000 # ?
+	break      0x40, 0x000 # 0x10000 ?
 	nop        
 error:
 	lui        $v0, %hi(SCE_ERROR_KERNEL_LIBRARY_IS_NOT_LINKED)

--- a/src/kd/sysmem/start.S
+++ b/src/kd/sysmem/start.S
@@ -801,7 +801,7 @@ loc_00000A70:
 
 loc_00000A7C:
     bltzl $a1, loc_00000A84
-    break 0x0
+    break
 
 loc_00000A84:
     li $v0, 8128


### PR DESCRIPTION
The "break" instruction is a bit ambiguous in the MIPS assebmler. It has a 20 bit immediate, but some assemblers treat it like a 10 bit constant (with 10 LSB as zero) and other as a full 20 bit immediate. The upstream MIPS binutils use the former while pspdev's branch uses the later.

Using the two immediate format (hi10, lo10) removes this ambiguity. I also removed "break 0" as simply "break".

