### PR TITLE
USB bus driver: API documentation fix and improvements

### DIFF
--- a/include/usbbus.h
+++ b/include/usbbus.h
@@ -2,10 +2,33 @@
    See the file COPYING for copying permission.
 */
 
-/** @defgroup Chkreg Chkreg Module
- *  Region check and ConsoleId service.
- * @{
+/** @defgroup USB USB management
+ *  Manages the UMD drive and accessing data on it.
  */
+
+ /** @defgroup USBBD USB Bus Driver
+  *  @ingroup USB
+  *
+  *  The USB bus driver manages the different USB protocol drivers currently
+  *  registered with it and communicates with the USB host as a single
+  *  USB device.
+  * 
+  *  Supported USB procotol drivers are as follows:
+  * 
+  *      • Camera USB
+  *        Capture image date from the PSP camera accessory via the USB port
+  * 
+  *      • GPS USB
+  *        Capture position information from the PSP GPS accessory via the USB port
+  * 
+  *      • Microphone (PCM) USB
+  *        Capture PCM data from the PSP microphone accessory via the USB port
+  * 
+  *      • PS2/PS3 USB
+  *        Allows PSP <-> PS2/PS3 data communication via the USB port 
+  *
+  * @{
+  */
 
 #ifndef USBBUS_H
 #define USBBUS_H

--- a/include/usbbus.h
+++ b/include/usbbus.h
@@ -3,7 +3,7 @@
 */
 
 /** @defgroup USB USB management
- *  Manages the UMD drive and accessing data on it.
+ *  Manages the communication between the PSP system and other hardware via the USB port.
  */
 
  /** @defgroup USBBD USB Bus Driver
@@ -13,7 +13,7 @@
   *  registered with it and communicates with the USB host as a single
   *  USB device.
   * 
-  *  Supported USB procotol drivers are as follows:
+  *  Supported USB protocol drivers are as follows:
   * 
   *      • Camera USB
   *        Capture image date from the PSP camera accessory via the USB port


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The API documentation for the USB bus driver was erroneously included in the API documentation for the chkreg module. This has been fixed.

In addition, information regarding the purpose of the USB bus driver has been provided.

## Motivation and Context
Fixes #139 

## How Has This Been Tested?
Simple API documentation fix.
