### PR TITLE
ctrl.c: Fix rsrv[0]/[1] -> rX,rY change

### DIFF
--- a/src/kd/ctrl/ctrl.c
+++ b/src/kd/ctrl/ctrl.c
@@ -1680,11 +1680,17 @@ static s32 _sceCtrlUpdateButtons(u32 rawButtons, u8 aX, u8 aY)
     tmpAnalogX = 0;
     tmpAnalogY = 0;
     
-    for (i = 0; i < sizeof ctrlUserBuf->rsrv; i++)
+    ctrlUserBuf->rX = 0;
+    ctrlUserBuf->rY = 0;
+    for (i = 0; i < sizeof ctrlUserBuf->rsrv; i++) {
          ctrlUserBuf->rsrv[i] = 0;
+    }
 
-    for (i = 0; i < sizeof ctrlKernelBuf->rsrv; i++)
+    ctrlKernelBuf->rX = 0;
+    ctrlKernelBuf->rY = 0;
+    for (i = 0; i < sizeof ctrlKernelBuf->rsrv; i++) {
          ctrlKernelBuf->rsrv[i] = 0;
+    }
 
 	/* Check for additionally registered input data transfers. */
 	for (i = 0; i < CTRL_NUM_EXTERNAL_PORTS; i++) {
@@ -1695,8 +1701,9 @@ static s32 _sceCtrlUpdateButtons(u32 rawButtons, u8 aX, u8 aY)
 			 transferInputFunc = (g_ctrl.transferHandler[i]->copyInputData);
 			 status = transferInputFunc(g_ctrl.extInputDataSource[i], ctrlKernelBufExt); // 0x00000F64
              if (status < 0) {
-                 for (j = 0; j < sizeof ctrlKernelBufExt->rsrv; j++)
+                 for (j = 0; j < sizeof ctrlKernelBufExt->rsrv; j++) {
                       ctrlKernelBufExt->rsrv[j] = 0;
+                 }
 
                  ctrlKernelBufExt->timeStamp = 0;
                  ctrlKernelBufExt->buttons = 0;
@@ -1710,8 +1717,8 @@ static s32 _sceCtrlUpdateButtons(u32 rawButtons, u8 aX, u8 aY)
                  ctrlKernelBufExt->TiltB = 0;
                  ctrlKernelBufExt->aX = CTRL_ANALOG_PAD_CENTER_VALUE;
                  ctrlKernelBufExt->aY = CTRL_ANALOG_PAD_CENTER_VALUE;
-                 ctrlKernelBufExt->rsrv[0] = -128;
-                 ctrlKernelBufExt->rsrv[1] = -128;
+                 ctrlKernelBufExt->rX = CTRL_ANALOG_PAD_CENTER_VALUE;
+                 ctrlKernelBufExt->rY = CTRL_ANALOG_PAD_CENTER_VALUE;
              }
              else {
                  if (g_ctrl.cancelIdleTimer == SCE_FALSE) {
@@ -1743,10 +1750,10 @@ static s32 _sceCtrlUpdateButtons(u32 rawButtons, u8 aX, u8 aY)
                      aYCenterOffset = (tmpAnalogY == (CTRL_ANALOG_PAD_CENTER_VALUE - 1)) ? CTRL_ANALOG_PAD_CENTER_VALUE : 
                                                                                            aYCenterOffset;
 
-                     aXCenterOffset2 = pspMax(ctrlKernelBufExt->rsrv[0] - CTRL_ANALOG_PAD_CENTER_VALUE, 
-                                              -ctrlKernelBufExt->rsrv[0] + CTRL_ANALOG_PAD_CENTER_VALUE);
-                     aYCenterOffset2 = pspMax(ctrlKernelBufExt->rsrv[1] - CTRL_ANALOG_PAD_CENTER_VALUE, 
-                                              -ctrlKernelBufExt->rsrv[1] + CTRL_ANALOG_PAD_CENTER_VALUE);
+                     aXCenterOffset2 = pspMax(ctrlKernelBufExt->rX - CTRL_ANALOG_PAD_CENTER_VALUE,
+                                              -ctrlKernelBufExt->rX + CTRL_ANALOG_PAD_CENTER_VALUE);
+                     aYCenterOffset2 = pspMax(ctrlKernelBufExt->rY - CTRL_ANALOG_PAD_CENTER_VALUE,
+                                              -ctrlKernelBufExt->rY + CTRL_ANALOG_PAD_CENTER_VALUE);
                      aXCenterOffset2 = (aXCenterOffset2 == (CTRL_ANALOG_PAD_CENTER_VALUE - 1)) ? 
                                                 CTRL_ANALOG_PAD_CENTER_VALUE : aXCenterOffset2;
                      aYCenterOffset2 = (aYCenterOffset2 == (CTRL_ANALOG_PAD_CENTER_VALUE - 1)) ? 
@@ -1762,9 +1769,12 @@ static s32 _sceCtrlUpdateButtons(u32 rawButtons, u8 aX, u8 aY)
              ctrlUserBufExt->buttons = ctrlKernelBufExt->buttons;
              ctrlUserBufExt->aX = ctrlKernelBufExt->aX;
              ctrlUserBufExt->aY = ctrlKernelBufExt->aY;
+             ctrlUserBufExt->rX = ctrlKernelBufExt->rX;
+             ctrlUserBufExt->rY = ctrlKernelBufExt->rY;
              
-             for (j = 0; j < sizeof ctrlUserBufExt->rsrv; j++)
+             for (j = 0; j < sizeof ctrlUserBufExt->rsrv; j++) {
                   ctrlUserBufExt->rsrv[j] = ctrlKernelBufExt->rsrv[j];
+             }
 
              ctrlUserBufExt->DPadSenseA = ctrlKernelBufExt->DPadSenseA;
              ctrlUserBufExt->DPadSenseB = ctrlKernelBufExt->DPadSenseB;
@@ -2152,11 +2162,11 @@ static s32 _sceCtrlReadBuf(SceCtrlData2 *pData, u8 nBufs, u32 port, u8 mode)
             * is an extended data buffer and fill it accordingly.
             */
            if (mode >= PEEK_BUFFER_POSITIVE_EXTRA) {
-			   pData->rsrv[0] = 0;
-			   pData->rsrv[1] = 0;
 			   if (port == SCE_CRTL_PORT_PSP) {
 				   pData->rX = CTRL_ANALOG_PAD_CENTER_VALUE;
 				   pData->rY = CTRL_ANALOG_PAD_CENTER_VALUE;
+				   pData->rsrv[0] = 0;
+				   pData->rsrv[1] = 0;
 				   pData->rsrv[2] = 0;
 				   pData->rsrv[3] = 0;
 				   pData->DPadSenseA = 0;
@@ -2171,6 +2181,8 @@ static s32 _sceCtrlReadBuf(SceCtrlData2 *pData, u8 nBufs, u32 port, u8 mode)
                else {
 				   pData->rX = ctrlBuf->rX;
 				   pData->rY = ctrlBuf->rY;
+				   pData->rsrv[0] = 0;
+				   pData->rsrv[1] = 0;
 				   pData->rsrv[2] = ctrlBuf->rsrv[2];
 				   pData->rsrv[3] = ctrlBuf->rsrv[3];
 				   pData->DPadSenseA = ctrlBuf->DPadSenseA;


### PR DESCRIPTION
Fix ctrl.c where the change to SceCtrlData to add rX and rY were missed. 

## Description
In commit f099b78dc0937df4e7346e2e417b63f471f8a3af, ctrl.h was changed. `SceCtrlData` and `SceCtrlDataExt` (now `SceCtrlData2`) were modified to replace the first two indices of the `rsrv[6]` array with discrete `Rx` and `Ry` variables (now `rX` and `rY`), representing right analogue stick position. The size of `rsrv` was reduced from 6 to 4.

This effectively changed:

`rsrv[0]` -> `Rx`
`rsrv[1]` -> `Ry`
`rsrv[2]` -> `rsrv[0]`
`rsrv[3]` -> `rsrv[1]`
`rsrv[4]` -> `rsrv[2]`
`rsrv[5]` -> `rsrv[3]`

ctrl.c was subsequently modified to react to this change, however some uses of `rsrv[0]` and `rsrv[1]` were missed, changing the behaviour of the code.

## Motivation and Context

Closes https://github.com/uofw/uofw/issues/145.